### PR TITLE
[HOPSWORKS-163] Add support for using GPU scheduling introduced in HOPS-11

### DIFF
--- a/tensorflowonspark/TFNode.py
+++ b/tensorflowonspark/TFNode.py
@@ -35,7 +35,7 @@ def hdfs_path(ctx, path):
       logging.warn("Unknown scheme {0} with relative path: {1}".format(ctx.defaultFS, path))
       return "{0}/{1}".format(ctx.defaultFS, path)
 
-def start_cluster_server(ctx, num_gpus=1, rdma=False):
+def start_cluster_server(ctx, num_gpus=0, rdma=False):
   """
   Wraps creation of TensorFlow Server in a distributed cluster.  This is intended to be invoked from the TF map_fun.
   """
@@ -52,16 +52,17 @@ def start_cluster_server(ctx, num_gpus=1, rdma=False):
     while not gpu_initialized:
       try:
         # override PS jobs to only reserve one GPU
-        if ctx.job_name == 'ps':
-          num_gpus = 1
+        # if ctx.job_name == 'ps':
+          # num_gpus = 0
 
         # Find a free gpu(s) to use
-        gpus_to_use = gpu_info.get_gpus(num_gpus)
-        gpu_prompt = "GPU" if num_gpus == 1 else "GPUs"
-        logging.info("{0}: Using {1}: {2}".format(ctx.worker_num, gpu_prompt, gpus_to_use))
+        # gpus_to_use = gpu_info.get_gpus(num_gpus)
+        # num_gpus = gpu_info.get_available_gpu_num()
+        # gpu_prompt = "GPU" if num_gpus == 1 else "GPUs"
+        # logging.info("{0}: Using {1}: {2}".format(ctx.worker_num, gpu_prompt, num_gpus))
 
         # Set GPU device to use for TensorFlow
-        os.environ['CUDA_VISIBLE_DEVICES'] = gpus_to_use
+        # os.environ['CUDA_VISIBLE_DEVICES'] = gpus_to_use
 
         # Create a cluster from the parameter server and worker hosts.
         cluster = tf.train.ClusterSpec(cluster_spec)
@@ -74,11 +75,11 @@ def start_cluster_server(ctx, num_gpus=1, rdma=False):
         gpu_initialized = True
       except Exception as e:
         print(e)
-        logging.error("{0}: Failed to allocate GPU, trying again...".format(ctx.worker_num))
-        time.sleep(10)
+        # logging.error("{0}: Failed to allocate GPU, trying again...".format(ctx.worker_num))
+        # time.sleep(10)
   else:
     # CPU
-    os.environ['CUDA_VISIBLE_DEVICES'] = ''
+    # os.environ['CUDA_VISIBLE_DEVICES'] = ''
     logging.info("{0}: Using CPU".format(ctx.worker_num))
 
     # Create a cluster from the parameter server and worker hosts.

--- a/tensorflowonspark/gpu_info.py
+++ b/tensorflowonspark/gpu_info.py
@@ -14,6 +14,8 @@ import random
 import subprocess
 import time
 
+import tensorflow as tf
+
 MAX_RETRIES=3
 
 def get_gpu():
@@ -81,6 +83,34 @@ def get_gpus(num_gpu=1):
     return ','.join(free_gpus[:num_gpu])
   except subprocess.CalledProcessError as e:
     print ("nvidia-smi error", e.output)
+
+def detect_gpu_present():
+    num_gpus = get_available_gpu_num()
+    if num_gpus > 0:
+     return True
+    else:
+     return False
+
+def get_available_gpu_num():
+   if tf.test.is_built_with_cuda() == False:
+     return 0
+   gpu_info = []
+   try:
+    gpu_info = subprocess.check_output(["nvidia-smi", "--format=csv,noheader,nounits", "--query-gpu=index,memory.total,memory.free,memory.used,utilization.gpu"]).decode()
+    gpu_info = gpu_info.split('\n')
+   except Exception as e:
+    return 0
+
+   gpu_info_array = []
+   # Check each gpu
+   for line in gpu_info:
+     if len(line) > 0:
+       val = line.split(',')
+       gpu_id, total_memory, free_memory, used_memory, gpu_util = line.split(',')
+
+       gpu_memory_util = float(used_memory)/float(total_memory)
+       gpu_info_array.append((float(gpu_util), gpu_memory_util, gpu_id))
+   return len(gpu_info_array)
 
 # Function to get the gpu information
 def get_free_gpu(max_gpu_utilization=40, min_free_memory=0.5, num_gpu=1):


### PR DESCRIPTION
[HOPSWORKS-163] TFoS currently uses node labels to identify machines with GPUs, and use RAM as a proxy to "schedule" a GPU card. It is not desirable since when the worker is allocated, it will attempt to use all the available GPUs, which means that GPUs may be unevenly distributed between workers. Furthermore 27GB is a huge memory spill, for a container with just 1 GPU. Instead, this patch adds support for HOPS-11 native GPU scheduling and isolation, in which a GPU can be requested and exclusively allocated for a worker. Issues that are solved in this patch include a coordination phase for TFoS, since a parameter may start on a container that have access to a GPU.